### PR TITLE
Fix class clobbering bug

### DIFF
--- a/addon/modifiers/themed.js
+++ b/addon/modifiers/themed.js
@@ -22,25 +22,39 @@ export default class ThemedModifier extends Modifier {
 
   updateTheme() {
     const { _lastTheme, _lastStyle, _lastVariant, theme, style, variant } = this;
-    if (this._lastStyle !== style) {
-      this._lastStyle = style;
-    }
-    if (this._lastVariant !== variant) {
-      this._lastVariant = variant;
-    }
-    if (this._lastTheme !== theme) {
-      this._lastTheme = theme;
-    }
+    if (this._lastStyle !== style) this._lastStyle = style;
+    if (this._lastVariant !== variant) this._lastVariant = variant;
+    if (this._lastTheme !== theme) this._lastTheme = theme;
     const fullLastStyle = _lastStyle ? `${_lastStyle}${_lastVariant ? '-' + _lastVariant : ''}` : null;
     const toRemove = this.emberThemed.getThemeStyle(_lastTheme, fullLastStyle);
-    toRemove.forEach(c => this.element.classList.remove(c));
+    this.element.classList.remove(...toRemove);
     // add new theme styles
     const fullNewStyle = style ? `${style}${variant ? '-' + variant : ''}` : null;
     const toAdd = this.emberThemed.getThemeStyle(theme, fullNewStyle);
-    toAdd.forEach(c => this.element.classList.add(c));
+    this.element.classList.add(...toAdd);
   }
 
   didReceiveArguments() {
     this.updateTheme();
+  }
+
+  didInstall() {
+    // use a mutation observer to re-add our classes if something else clobbers them
+    this._mutationObserver = new MutationObserver((mutations) => {
+      mutations.forEach(({ type, attributeName }) => {
+        if (type === 'attributes' && attributeName === 'class') {
+          const fullStyle = this.style ? `${this.style}${this.variant ? '-' + this.variant : ''}` : null;
+          const classes = this.emberThemed.getThemeStyle(this.theme, fullStyle);
+          if (!classes.every(c => this.element.classList.contains(c))) {
+            this.element.classList.add(...classes);
+          }
+        }
+      });
+    });
+    this._mutationObserver.observe(this.element, { attributes: true });
+  }
+
+  willRemove() {
+    this._mutationObserver.disconnect();
   }
 }

--- a/tests/integration/modifiers/themed-test.js
+++ b/tests/integration/modifiers/themed-test.js
@@ -115,4 +115,15 @@ module('Integration | Modifier | themed', function(hooks) {
     // assert applying style with variant works as expected
     onlyHasStyle(assert, '#modified', this.emberThemed, 'dark', 'card', 'red');
   });
+
+  test('modifying css classes on the element does not clobber the theme classes', async function(assert) {
+    await render(hbs`<div id="modified" class={{this.extraClass}} {{themed "branded"}}></div>`);
+    this.emberThemed = this.owner.lookup('service:ember-themed');
+
+    this.set('extraClass', 'new-class');
+
+    ['new-class', 'light-brand-color', 'light-brand-text'].forEach(className => {
+      assert.dom('#modified').hasClass(className);
+    });
+  });
 });

--- a/tests/integration/modifiers/themed-test.js
+++ b/tests/integration/modifiers/themed-test.js
@@ -121,6 +121,7 @@ module('Integration | Modifier | themed', function(hooks) {
     this.emberThemed = this.owner.lookup('service:ember-themed');
 
     this.set('extraClass', 'new-class');
+    await settled();
 
     ['new-class', 'light-brand-color', 'light-brand-text'].forEach(className => {
       assert.dom('#modified').hasClass(className);

--- a/tests/integration/modifiers/themed-test.js
+++ b/tests/integration/modifiers/themed-test.js
@@ -120,10 +120,10 @@ module('Integration | Modifier | themed', function(hooks) {
     await render(hbs`<div id="modified" class={{this.extraClass}} {{themed "branded"}}></div>`);
     this.emberThemed = this.owner.lookup('service:ember-themed');
 
-    this.set('extraClass', 'new-class');
+    this.set('extraClass', 'extra-class');
     await settled();
 
-    ['new-class', 'light-brand-color', 'light-brand-text'].forEach(className => {
+    ['extra-class', 'light-brand-color', 'light-brand-text'].forEach(className => {
       assert.dom('#modified').hasClass(className);
     });
   });


### PR DESCRIPTION
Uses mutation observer to make sure if something else clobbers the element classes the modifier can reapply them.

Closes #5 